### PR TITLE
build: add 'CMAKE_CXX_STANDARD 11'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required ( VERSION 3.18 )
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 project ( wasm-tools )
 
 include(FetchContent)


### PR DESCRIPTION
This was needed to have this compile on my macos machine.

Before, I ran into errors like

    "error: delegating constructors are permitted only in C++11"

Found the fix searching for that in this issue:
https://github.com/wjakob/nanogui/issues/302